### PR TITLE
MAINT: CFEP-25 python_min for asv_runner 0.2.5

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -6,3 +6,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+
+python_min:
+- 3.9

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,15 +13,15 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
-    - python >=3.7
+    - python {{ python_min }}
     - pdm-backend
     - pip
   run:
-    - python >=3.7
+    - python >={{ python_min }}
     - importlib-metadata
 
 test:
@@ -30,6 +30,7 @@ test:
   commands:
     - pip check
   requires:
+    - python {{ python_min }}
     - pip
 
 about:


### PR DESCRIPTION
Address conda-forge-linting CFEP-25 hints on the 0.2.5 recipe:

- `host`: `python {{ python_min }}`
- `run`: `python >={{ python_min }}`
- `test.requires`: `python {{ python_min }}`

Bump **build number to 1** so the noarch package is rebuilt and re-uploaded (helps downstream **asv** feedstock solve `asv_runner >=0.2.5` on all platforms).

Source remains the GitHub `v0.2.5` tag archive (PyPI still wheel-only for this version).