### PR TITLE
REBUILD: asv_runner 0.2.5 build 2 (channel CDN)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 2
 
 requirements:
   host:


### PR DESCRIPTION
**0.2.5** appears on anaconda.org package API but **not** on \`conda.anaconda.org/conda-forge/noarch/\` (HTTP 404 for \`pyhd8ed1ab_0\` / \`_1\`). Solvers report \`asv_runner >=0.2.5 does not exist\`, so **asv-feedstock** CI stays red.

Bump **build number → 2** to force a clean conda-forge upload into the CDN/repodata path used by CI.